### PR TITLE
CB-32599 copy-image fix following transition to managed images and updating az cli base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM mcr.microsoft.com/azure-cli:latest
+FROM mcr.microsoft.com/azure-cli:azurelinux3.0
 
-MAINTAINER Hortonworks
+LABEL MAINTAINER=Hortonworks
 
 WORKDIR /bin
 
-RUN apk update && apk add bash coreutils jq curl
+RUN tdnf install -y tar && tdnf clean all
 
 ADD ./azure-copy /bin/
 ADD ./azure-get-latest-vm-image-version /bin/
 
 RUN curl -Lsf https://github.com/hortonworks/pollprogress/releases/download/v1.1/pollprogress_1.1_Linux_x86_64.tgz | tar -xz -C /bin
-ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/azure/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/azure/bin
 
 ENTRYPOINT ["/bin/pollprogress"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 VERSION=$(shell git  describe --tags --abbrev=0)
 REPOSITORY=cloudbreak-tools/cloudbreak-azure-cli-tools
 
+.PHONY: build build-dev release release-dev dev-all
+
 build:
 	docker build -t $(REPOSITORY):$(VERSION) .
 
@@ -10,3 +12,11 @@ build-dev:
 release:
 	docker tag $(REPOSITORY):$(VERSION) docker-sandbox.infra.cloudera.com/$(REPOSITORY):$(VERSION)
 	docker push docker-sandbox.infra.cloudera.com/$(REPOSITORY):$(VERSION)
+
+release-dev:
+	docker tag $(REPOSITORY):dev docker-sandbox.infra.cloudera.com/$(REPOSITORY):dev
+	docker push docker-sandbox.infra.cloudera.com/$(REPOSITORY):dev
+
+dev-all:
+	make build-dev
+	make release-dev

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 VERSION=$(shell git  describe --tags --abbrev=0)
 REPOSITORY=cloudbreak-tools/cloudbreak-azure-cli-tools
+PLATFORMS=linux/amd64,linux/arm64
 
 .PHONY: build build-dev release release-dev dev-all
 
 build:
-	docker build -t $(REPOSITORY):$(VERSION) .
+	docker build --platform $(PLATFORMS) -t $(REPOSITORY):$(VERSION) .
 
 build-dev:
-	docker build -t $(REPOSITORY):dev .
+	docker build --platform $(PLATFORMS) -t $(REPOSITORY):dev .
 
 release:
 	docker tag $(REPOSITORY):$(VERSION) docker-sandbox.infra.cloudera.com/$(REPOSITORY):$(VERSION)

--- a/azure-copy
+++ b/azure-copy
@@ -47,6 +47,10 @@ get_storage_accounts_to_copy() {
 azure_copy_everywhere() {
     local vhdPath=$(azure_latest_vhd_by_prefix $AZURE_IMAGE_NAME)
     debug "vhdPath=$vhdPath"
+    if [ -z "$vhdPath" ]; then
+        echo vhdPath is empty.
+        exit 1
+    fi
     local sourceBlob="$ARM_STORAGE_ACCOUNT/images/${vhdPath}"
     debug "sourceBlob=$sourceBlob"
 

--- a/azure-copy
+++ b/azure-copy
@@ -47,7 +47,7 @@ get_storage_accounts_to_copy() {
 azure_copy_everywhere() {
     local vhdPath=$(azure_latest_vhd_by_prefix $AZURE_IMAGE_NAME)
     debug "vhdPath=$vhdPath"
-    local sourceBlob="$ARM_STORAGE_ACCOUNT/system/${vhdPath}"
+    local sourceBlob="$ARM_STORAGE_ACCOUNT/images/${vhdPath}"
     debug "sourceBlob=$sourceBlob"
 
     rm -f checks.yml
@@ -139,8 +139,8 @@ azure_latest_vhd_by_prefix() {
     az storage blob list \
         --account-name $ARM_STORAGE_ACCOUNT \
         --account-key $key \
-        --container-name system \
-        --prefix Microsoft.Compute/Images/packer/${imageName}-osDisk \
+        --container-name images \
+        --prefix ${imageName}.vhd \
         --output json \
         | jq '.[].name' -r
 }


### PR DESCRIPTION

Following changes to the burn job in https://cloudera.atlassian.net/browse/CB-32422 the copying mechanism had to be fixed. Additionally we check if we can't find the source blob and fail early.

Additional changes:

1. MS no longer supports Alpine based images. Migrated to azure linux which is RPM based and uses `tdnf` for package management. Default package set is different; updated accordingly.
2. As arm64 macbooks are prevalent the docker build is now by default multi-platform: x64 + arm64 so it can be used for easy local testing and also works on the jenkins runners.
3. `dev-all` make target introduced to quickly push `dev` tag for testing.
4. Small fixes for deprecated features in the Dockerfile: MAINTAINER is deprecated, applied label instead. ENV requires key=value pair format.

Test jobs:

1. https://build.eng.cloudera.com/job/cloudbreak-copy-image/549
2. https://build.eng.cloudera.com/job/cloudbreak-copy-image/550
3. https://build.eng.cloudera.com/job/cloudbreak-copy-image/551